### PR TITLE
Release Version 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.10.1](https://github.com/BluStor/GateKeeperSDK/releases/tag/v0.10.1)
+* Fix data upload
+    * Previously, when calling GKBluetoothCard.put data would be sent in chunks of 512 bytes. The method
+    used to buffer this data did not reset the buffer or send the correct size of the data, causing
+    any data that was longer than 512 bytes (and not a multiple of 512) to get garbage data in the last
+    `N - (N % 512)` bytes.
+* Rename `GKBluetoothMultiplexer` to `GKMultiplexer` and make it generic enough to handle IO streams only
+* Add `GKMultiplexer.writeToDataChannel(InputStream inputStream)` to handle chunked data transfer
+
 ## [v0.10.0](https://github.com/BluStor/GateKeeperSDK/releases/tag/v0.10.0)
 
 * Rename `GKAuthentication.enrollWithPin` to `GKAuthentication.enrollWithRecoveryCode`

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 19
-        versionCode 12
-        versionName "0.10.0"
+        versionCode 13
+        versionName "0.10.1"
     }
 
     buildTypes {

--- a/app/src/main/java/co/blustor/gatekeepersdk/devices/GKBluetoothCard.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/devices/GKBluetoothCard.java
@@ -34,8 +34,6 @@ public class GKBluetoothCard implements GKCard {
     private static final String RMD = "RMD";
     private static final String SRFT = "SRFT";
 
-    private static final int UPLOAD_DELAY_MILLIS = 1;
-
     private final String mCardName;
     private GKMultiplexer mMultiplexer;
     private List<Monitor> mCardMonitors = new ArrayList<>();

--- a/app/src/test/java/co/blustor/gatekeepersdk/data/GKMultiplexerTest.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/data/GKMultiplexerTest.java
@@ -1,0 +1,63 @@
+package co.blustor.gatekeepersdk.data;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class GKMultiplexerTest {
+
+    private GKMultiplexer multiplexer;
+    private ByteArrayOutputStream outputStream;
+
+    @Before
+    public void setUp() {
+        InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        outputStream = new ByteArrayOutputStream();
+        multiplexer = new GKMultiplexer(inputStream, outputStream);
+    }
+
+    @Test
+    public void writeToCommandChannelConstructsPacketAndWritesItToCommandChannel() throws IOException {
+        byte[] input = {'x', 'y', 'z', 'j'};
+
+        multiplexer.writeToCommandChannel(input);
+
+        byte[] expectedPacket = {GKMultiplexer.COMMAND_CHANNEL, 0, 9, 'x', 'y', 'z', 'j', 0, 0};
+        assertThat(outputStream.toByteArray(), is(Matchers.equalTo(expectedPacket)));
+    }
+
+    @Test
+    public void writeToDataChannelConstructsPacketAndWritesItToDataChannel() throws IOException {
+        byte[] input = {'x', 'y', 'z', 'j'};
+
+        multiplexer.writeToDataChannel(input);
+
+        byte[] expectedPacket = {GKMultiplexer.DATA_CHANNEL, 0, 9, 'x', 'y', 'z', 'j', 0, 0};
+        assertThat(outputStream.toByteArray(), is(Matchers.equalTo(expectedPacket)));
+    }
+
+    @Test
+    public void writeToDataChannelWithInputStreamBuffersPackets() throws Exception {
+        byte[] input = new byte[GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 1];
+        Arrays.fill(input, (byte) 'x');
+
+        multiplexer.writeToDataChannel(new ByteArrayInputStream(input));
+
+        // should write in 2 packets of up to 512 bytes each, so 5 extra bytes per packet
+        assertThat(outputStream.toByteArray().length, is(equalTo(523)));
+        byte[] firstPacketStart = {GKMultiplexer.DATA_CHANNEL, 2, 5, 'x'};
+        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), 0, 4), is(Matchers.equalTo(firstPacketStart)));
+        byte[] secondPacket = {GKMultiplexer.DATA_CHANNEL, 0, 6, 'x', 0, 0};
+        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), 517, 523), is(Matchers.equalTo(secondPacket)));
+    }
+}


### PR DESCRIPTION
* Fix data upload
    * Previously, when calling GKBluetoothCard.put data would be sent in chunks of 512 bytes. The method
    used to buffer this data did not reset the buffer or send the correct size of the data, causing
    any data that was longer than 512 bytes (and not a multiple of 512) to get garbage data in the last
    `N - (N % 512)` bytes.
* Rename `GKBluetoothMultiplexer` to `GKMultiplexer` and make it generic enough to handle IO streams only
* Add `GKMultiplexer.writeToDataChannel(InputStream inputStream)` to handle chunked data transfer