### PR TITLE
FIX: write all data from data channel directly to file, do not store in buffer

### DIFF
--- a/app/src/main/java/co/blustor/gatekeepersdk/data/DataPacket.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/data/DataPacket.java
@@ -1,0 +1,109 @@
+package co.blustor.gatekeepersdk.data;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DataPacket {
+    public static final int HEADER_SIZE = 3;
+    public static final int CHECKSUM_SIZE = 2;
+
+    public static final byte MOST_SIGNIFICANT_BIT = 0x00;
+    public static final byte LEAST_SIGNIFICANT_BIT = 0x00;
+
+    private byte[] mPayload;
+    private int mChannel;
+
+    public DataPacket(byte[] payload, int channel) {
+        mPayload = payload;
+        mChannel = channel;
+    }
+
+    public byte[] getPayload() {
+        return mPayload;
+    }
+
+    public int getChannel() {
+        return mChannel;
+    }
+
+    public static class Builder {
+        public static DataPacket build(InputStream inputStream) throws IOException {
+            byte[] header = readHeader(inputStream);
+            int packetSize = getPacketSize(header);
+            int channel = getPacketChannel(header);
+            byte[] payload = readPayload(inputStream, packetSize);
+            byte[] checksum = readChecksum(inputStream);
+
+            return new DataPacket(payload, channel);
+        }
+
+        public static byte[] toPacketBytes(byte[] data, int channel) {
+            int packetSize = data.length + 5;
+            byte channelByte = getChannelByte(channel);
+            byte msb = getMSB(packetSize);
+            byte lsb = getLSB(packetSize);
+
+            byte[] packet = new byte[data.length + 5];
+            packet[0] = channelByte;
+            packet[1] = msb;
+            packet[2] = lsb;
+            for (int i = 0; i < data.length; i++) {
+                packet[i + 3] = data[i];
+            }
+
+            packet[packet.length - 2] = DataPacket.MOST_SIGNIFICANT_BIT;
+            packet[packet.length - 1] = DataPacket.LEAST_SIGNIFICANT_BIT;
+            return packet;
+        }
+
+        private static int getPacketSize(byte[] header) {
+            byte packetSizeMSB = header[1];
+            byte packetSizeLSB = header[2];
+            int packetSize = (int) packetSizeMSB << 8;
+            packetSize += (int) packetSizeLSB & 0xFF;
+            return packetSize;
+        }
+
+        private static int getPacketChannel(byte[] header) {
+            return (int) header[0];
+        }
+
+        private static byte[] readHeader(InputStream inputStream) throws IOException {
+            return fillByteArrayFromStream(inputStream, DataPacket.HEADER_SIZE);
+        }
+
+        private static byte[] readPayload(InputStream inputStream, int packetSize) throws IOException {
+            int payloadsize = packetSize - (DataPacket.HEADER_SIZE + DataPacket.CHECKSUM_SIZE);
+            return fillByteArrayFromStream(inputStream, payloadsize);
+        }
+
+        private static byte[] readChecksum(InputStream inputStream) throws IOException {
+            return fillByteArrayFromStream(inputStream, DataPacket.CHECKSUM_SIZE);
+        }
+
+        private static byte[] fillByteArrayFromStream(InputStream inputStream, int length) throws IOException {
+            byte[] data = new byte[length];
+            int totalBytesRead = 0;
+            int bytesRead = 0;
+            while (totalBytesRead < length && bytesRead != -1) {
+                bytesRead = inputStream.read(data, totalBytesRead, length - totalBytesRead);
+                if (bytesRead != -1) {
+                    totalBytesRead += bytesRead;
+                }
+            }
+            return data;
+        }
+
+        private static byte getChannelByte(int channel) {
+            return (byte) (channel & 0xff);
+        }
+
+        private static byte getMSB(int size) {
+            return (byte) (size >> 8);
+        }
+
+        private static byte getLSB(int size) {
+            return (byte) (size & 0xff);
+        }
+    }
+}

--- a/app/src/main/java/co/blustor/gatekeepersdk/data/GKMultiplexer.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/data/GKMultiplexer.java
@@ -3,14 +3,12 @@ package co.blustor.gatekeepersdk.data;
 import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Intended for internal use only.
@@ -20,25 +18,13 @@ public class GKMultiplexer {
     public static final int MAXIMUM_PAYLOAD_SIZE = 256;
     public static final int COMMAND_CHANNEL = 1;
     public static final int DATA_CHANNEL = 2;
-    public static final int MAX_CHANNEL_NUMBER = 2;
 
     private static final byte CARRIAGE_RETURN = 13;
     private static final byte LINE_FEED = 10;
-    private static final byte TERMINATE_CHANNEL_BYTE = Byte.MAX_VALUE;
     private static final int UPLOAD_DELAY_MILLIS = 1;
 
     private InputStream mInputStream;
     private OutputStream mOutputStream;
-    private BlockingQueue<Byte>[] mChannelBuffers = new LinkedBlockingQueue[MAX_CHANNEL_NUMBER + 1];
-    private Thread mBufferingThread;
-
-    private boolean mExiting = false;
-
-    {
-        for (int i = 0; i <= MAX_CHANNEL_NUMBER; i++) {
-            mChannelBuffers[i] = new LinkedBlockingQueue<>();
-        }
-    }
 
     public GKMultiplexer(InputStream inputStream, OutputStream outputStream) {
         mInputStream = inputStream;
@@ -70,228 +56,84 @@ public class GKMultiplexer {
         } while (bytesRead != -1);
     }
 
-    public byte[] readCommandChannelLine() throws IOException, InterruptedException {
-        return readLine(COMMAND_CHANNEL);
+    public byte[] readCommandChannelLine() throws IOException {
+        DataPacket packet = DataPacket.Builder.build(mInputStream);
+        return readCommandLine(packet);
     }
 
-    public byte[] readDataChannel() throws IOException, InterruptedException {
-        List<Byte> byteList = new ArrayList<>();
-        mChannelBuffers[DATA_CHANNEL].drainTo(byteList);
-        byte[] bytes = new byte[byteList.size()];
-        for (int i = 0; i < bytes.length; i++) {
-            bytes[i] = byteList.get(i);
-        }
-        return bytes;
-    }
-
-    public void connect() throws IOException {
-        mBufferingThread = new Thread(new ChannelBuffer());
-        mBufferingThread.start();
-    }
-
-    public void disconnect() {
-        mBufferingThread.interrupt();
-        cleanup();
-    }
-
-    private void cleanup() {
+    /**
+     * Read from the data channel and write it to the specified file. Once a response is read from
+     * the command channel, we are done reading data and can return the command response
+     *
+     * @param dataFile the {@code File} to write the data channel to
+     * @return the data read from the command channel following data transfer
+     * @throws IOException when connection to the card is disrupted or writing data to a file fails
+     */
+    public byte[] readDataChannelToFile(File dataFile) throws IOException {
+        FileOutputStream fileOutputStream = null;
         try {
-            mExiting = true;
-            terminateChannelReaders();
+            fileOutputStream = new FileOutputStream(dataFile);
+            DataPacket packet = DataPacket.Builder.build(mInputStream);
+
+            while (DATA_CHANNEL == packet.getChannel()) {
+                byte[] payload = packet.getPayload();
+                fileOutputStream.write(payload);
+                packet = DataPacket.Builder.build(mInputStream);
+            }
+
+            return readCommandLine(packet);
+        } catch (IOException e) {
+            Log.e(TAG, "Exception occurred while buffering a DataPacket", e);
+            cleanup();
+            throw e;
+        } finally {
+            if (fileOutputStream != null) {
+                fileOutputStream.close();
+            }
+        }
+    }
+
+    public void cleanup() {
+        try {
             mInputStream.close();
             mOutputStream.close();
         } catch (IOException e) {
             Log.e(TAG, "Exception occurred during cleanup", e);
-        } catch (InterruptedException e) {
-            Log.e(TAG, "InterruptedException occurred during cleanup", e);
         }
     }
 
-    private void terminateChannelReaders() throws InterruptedException {
-        for (int i = 0; i <= MAX_CHANNEL_NUMBER; i++) {
-            mChannelBuffers[i].put(TERMINATE_CHANNEL_BYTE);
-        }
-    }
-
-    private void write(byte[] data, int channel) throws IOException {
-        byte[] packetBytes = DataPacketBuilder.toPacketBytes(data, channel);
-        mOutputStream.write(packetBytes);
-    }
-
-    private byte[] readLine(int channel) throws IOException, InterruptedException {
+    private byte[] readCommandLine(DataPacket packet) throws IOException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        byte a = read(channel);
-        byte b = read(channel);
-        while (a != CARRIAGE_RETURN && b != LINE_FEED) {
+        while (!containsCRLF(packet.getPayload())) {
+            copyUntilCRLF(packet.getPayload(), bytes);
+            packet = DataPacket.Builder.build(mInputStream);
+        }
+        copyUntilCRLF(packet.getPayload(), bytes);
+        return bytes.toByteArray();
+    }
+
+    private boolean containsCRLF(byte[] payload) {
+        for (int i = 0; i < payload.length - 1; i++) {
+            if (payload[i] == CARRIAGE_RETURN && payload[i + 1] == LINE_FEED) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private byte[] copyUntilCRLF(byte[] data, ByteArrayOutputStream bytes) throws IOException {
+        for (int i = 0; i < data.length; i++) {
+            byte a = data[i];
+            if (a == CARRIAGE_RETURN && i < data.length - 1 && data[i + 1] == LINE_FEED) {
+                break;
+            }
             bytes.write(a);
-            a = b;
-            b = read(channel);
         }
         return bytes.toByteArray();
     }
 
-    private byte read(int channel) throws IOException, InterruptedException {
-        byte[] buffer = new byte[1];
-        read(buffer, channel);
-        return buffer[0];
-    }
-
-    private int read(byte[] data, int channel) throws IOException, InterruptedException {
-        int bytesRead = 0;
-        int totalRead = 0;
-        while (totalRead < data.length && bytesRead != -1) {
-            bytesRead = readFromBuffer(data, bytesRead, data.length - bytesRead, channel);
-            if (bytesRead != -1) {
-                totalRead += bytesRead;
-            }
-        }
-        return totalRead;
-    }
-
-    private int readFromBuffer(byte[] data, int off, int len, int channel) throws IOException, InterruptedException {
-        BlockingQueue<Byte> buffer = mChannelBuffers[channel];
-        int bytesRead = 0;
-        for (int i = 0; i < len; i++) {
-            Byte byteTaken = buffer.take();
-            if (mExiting && (byteTaken == TERMINATE_CHANNEL_BYTE)) {
-                throw new IOException("Discontinuing reading from Byte buffers");
-            }
-            data[off + i] = byteTaken;
-            bytesRead = i;
-        }
-        return bytesRead + 1;
-    }
-
-    private static class DataPacket {
-        public static final int HEADER_SIZE = 3;
-        public static final int CHECKSUM_SIZE = 2;
-
-        public static final byte MOST_SIGNIFICANT_BIT = 0x00;
-        public static final byte LEAST_SIGNIFICANT_BIT = 0x00;
-
-        private byte[] mPayload;
-        private int mChannel;
-
-        public DataPacket(byte[] payload, int channel) {
-            mPayload = payload;
-            mChannel = channel;
-        }
-
-        public byte[] getPayload() {
-            return mPayload;
-        }
-
-        public int getChannel() {
-            return mChannel;
-        }
-    }
-
-    private static class DataPacketBuilder {
-        public static final String TAG = DataPacketBuilder.class.getSimpleName();
-
-        public static DataPacket build(InputStream inputStream) throws IOException {
-            byte[] header = readHeader(inputStream);
-            int packetSize = getPacketSize(header);
-            int channel = getPacketChannel(header);
-            byte[] payload = readPayload(inputStream, packetSize);
-            byte[] checksum = readChecksum(inputStream);
-
-            return new DataPacket(payload, channel);
-        }
-
-        public static byte[] toPacketBytes(byte[] data, int channel) {
-            int packetSize = data.length + 5;
-            byte channelByte = getChannelByte(channel);
-            byte msb = getMSB(packetSize);
-            byte lsb = getLSB(packetSize);
-
-            byte[] packet = new byte[data.length + 5];
-            packet[0] = channelByte;
-            packet[1] = msb;
-            packet[2] = lsb;
-            for (int i = 0; i < data.length; i++) {
-                packet[i + 3] = data[i];
-            }
-
-            packet[packet.length - 2] = DataPacket.MOST_SIGNIFICANT_BIT;
-            packet[packet.length - 1] = DataPacket.LEAST_SIGNIFICANT_BIT;
-            return packet;
-        }
-
-        private static int getPacketSize(byte[] header) {
-            byte packetSizeMSB = header[1];
-            byte packetSizeLSB = header[2];
-            int packetSize = (int) packetSizeMSB << 8;
-            packetSize += (int) packetSizeLSB & 0xFF;
-            return packetSize;
-        }
-
-        private static int getPacketChannel(byte[] header) {
-            return (int) header[0];
-        }
-
-        private static byte[] readHeader(InputStream inputStream) throws IOException {
-            return fillByteArrayFromStream(inputStream, DataPacket.HEADER_SIZE);
-        }
-
-        private static byte[] readPayload(InputStream inputStream, int packetSize) throws IOException {
-            int payloadsize = packetSize - (DataPacket.HEADER_SIZE + DataPacket.CHECKSUM_SIZE);
-            return fillByteArrayFromStream(inputStream, payloadsize);
-        }
-
-        private static byte[] readChecksum(InputStream inputStream) throws IOException {
-            return fillByteArrayFromStream(inputStream, DataPacket.CHECKSUM_SIZE);
-        }
-
-        private static byte[] fillByteArrayFromStream(InputStream inputStream, int length) throws IOException {
-            byte[] data = new byte[length];
-            int totalBytesRead = 0;
-            int bytesRead = 0;
-            while (totalBytesRead < length && bytesRead != -1) {
-                bytesRead = inputStream.read(data, totalBytesRead, length - totalBytesRead);
-                if (bytesRead != -1) {
-                    totalBytesRead += bytesRead;
-                }
-            }
-            return data;
-        }
-
-        private static byte getChannelByte(int channel) {
-            return (byte) (channel & 0xff);
-        }
-
-        private static byte getMSB(int size) {
-            return (byte) (size >> 8);
-        }
-
-        private static byte getLSB(int size) {
-            return (byte) (size & 0xff);
-        }
-    }
-
-    private class ChannelBuffer implements Runnable {
-        public void run() {
-            while (true) {
-                try {
-                    bufferNextPacket();
-                } catch (IOException e) {
-                    Log.e(TAG, "Exception occurred while buffering a DataPacket", e);
-                    cleanup();
-                    return;
-                } catch (InterruptedException e) {
-                    Log.e(TAG, "ChannelBuffer interrupted", e);
-                    return;
-                }
-            }
-        }
-
-        private void bufferNextPacket() throws IOException, InterruptedException {
-            DataPacket packet = DataPacketBuilder.build(mInputStream);
-            BlockingQueue<Byte> buffer = mChannelBuffers[packet.getChannel()];
-            byte[] bytes = packet.getPayload();
-            for (int i = 0; i < bytes.length; i++) {
-                buffer.put(bytes[i]);
-            }
-        }
+    private void write(byte[] data, int channel) throws IOException {
+        byte[] packetBytes = DataPacket.Builder.toPacketBytes(data, channel);
+        mOutputStream.write(packetBytes);
     }
 }

--- a/app/src/main/java/co/blustor/gatekeepersdk/devices/GKCard.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/devices/GKCard.java
@@ -1,5 +1,6 @@
 package co.blustor.gatekeepersdk.devices;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -16,6 +17,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response list(String cardPath) throws IOException;
+
     /**
      * Send a `get` action to the GateKeeper Card.
      *
@@ -25,6 +27,18 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response get(String cardPath) throws IOException;
+
+    /**
+     * Send a `get` action to the GateKeeper Card.
+     *
+     * @param cardPath the path used in the action
+     * @param localFile the local file used to store the response data
+     * @return a {@code Response} with information about the action
+     * @throws IOException when communication with the GateKeeper Card has been disrupted.
+     * @since 0.16.0
+     */
+    Response get(String cardPath, File localFile) throws IOException;
+
     /**
      * Send a `put` action to the GateKeeper Card.
      *
@@ -35,6 +49,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response put(String cardPath, InputStream inputStream) throws IOException;
+
     /**
      * Send a `delete` action to the GateKeeper Card.
      *
@@ -44,6 +59,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response delete(String cardPath) throws IOException;
+
     /**
      * Send a `createPath` action to the GateKeeper Card.
      *
@@ -53,6 +69,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response createPath(String cardPath) throws IOException;
+
     /**
      * Send a `deletePath` action to the GateKeeper Card.
      *
@@ -62,6 +79,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response deletePath(String cardPath) throws IOException;
+
     /**
      * Send a `finalize` action to the GateKeeper Card.
      *
@@ -71,6 +89,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     Response finalize(String cardPath) throws IOException;
+
     /**
      * Open a connection with the GateKeeper Card.
      *
@@ -78,6 +97,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     void connect() throws IOException;
+
     /**
      * Close the connection with the GateKeeper Card.
      *
@@ -85,6 +105,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     void disconnect() throws IOException;
+
     /**
      * Get the current state of the connection between this object and the GateKeeper Card.
      *
@@ -93,11 +114,14 @@ public interface GKCard {
      * @since 0.5.0
      */
     ConnectionState getConnectionState();
+
     /**
      * Intended for internal use only.
+     *
      * @param state the {@code ConnectionState} that describes the new state of the connection
      */
     void onConnectionChanged(ConnectionState state);
+
     /**
      * Add a {@code Monitor} to be informed about changes to the state of the GateKeeper Card.
      *
@@ -105,6 +129,7 @@ public interface GKCard {
      * @since 0.5.0
      */
     void addMonitor(Monitor monitor);
+
     /**
      * Remove a {@code Monitor} from the {@code GKCard}.
      *
@@ -183,20 +208,20 @@ public interface GKCard {
         protected String mMessage;
 
         /**
-         * Any data received during execution of the action.
+         * The {@code File} representing the location that any data is stored from a response
          */
-        protected byte[] mData;
+        protected File mDataFile;
 
         /**
          * Create a {@code Response} with the basic attributes of the given {@code Response}.
          *
          * @param response the {@code Response} object to copy
-         * @since 0.5.0
+         * @since 0.16.0
          */
         public Response(Response response) {
             mStatus = response.getStatus();
             mMessage = response.getMessage();
-            mData = response.getData();
+            mDataFile = response.getDataFile();
         }
 
         /**
@@ -212,6 +237,20 @@ public interface GKCard {
         }
 
         /**
+         * Create a {@code Response} with the given status code, message, and dataFile.
+         *
+         * @param status   the numeric status code to classify this response
+         * @param message  the {@code String} message to describe this response
+         * @param dataFile the {@code File} that holds body data for this response
+         * @since 0.16.0
+         */
+        public Response(int status, String message, File dataFile) {
+            mStatus = status;
+            mMessage = message;
+            mDataFile = dataFile;
+        }
+
+        /**
          * Create a {@code Response} with the given command data.
          *
          * @param commandData the data containing the status code and message
@@ -224,18 +263,18 @@ public interface GKCard {
         /**
          * Create a {@code Response} with the given command and body data.
          *
-         * @param commandData the data containing the status code and message
-         * @param bodyData    the data of the body
-         * @since 0.5.0
+         * @param commandData  the data containing the status code and message
+         * @param bodyDataFile the {@code File} containing body data
+         * @since 0.16.0
          */
-        public Response(byte[] commandData, byte[] bodyData) {
+        public Response(byte[] commandData, File bodyDataFile) {
             String responseString = new String(commandData);
             String[] split = responseString.split("\\s", 2);
             mStatus = Integer.parseInt(split[0]);
             if (split.length > 1) {
                 mMessage = split[1];
             }
-            mData = bodyData;
+            mDataFile = bodyDataFile;
         }
 
         /**
@@ -271,21 +310,21 @@ public interface GKCard {
         /**
          * Retrieve the body data of the Response.
          *
-         * @return the body data
-         * @since 0.5.0
+         * @return the {@code File} that hold the response data
+         * @since 0.16.0
          */
-        public byte[] getData() {
-            return mData;
+        public File getDataFile() {
+            return mDataFile;
         }
 
         /**
-         * Assign the body data of the Response.
+         * Assign the file that holds the Response data.
          *
-         * @param data the body data
-         * @since 0.5.0
+         * @param dataFile the {@code File} that holds response data
+         * @since 0.16.0
          */
-        public void setData(byte[] data) {
-            mData = data;
+        public void setDataFile(File dataFile) {
+            mDataFile = dataFile;
         }
     }
 

--- a/app/src/main/java/co/blustor/gatekeepersdk/services/GKAuthentication.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/services/GKAuthentication.java
@@ -1,6 +1,9 @@
 package co.blustor.gatekeepersdk.services;
 
+import android.util.Log;
+
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -86,7 +89,7 @@ public class GKAuthentication {
      * Store a recovery code at the given template index on the GateKeeper Card.
      *
      * @param recoveryCode the String to be stored
-     * @param templateId the id at which to store the recovery code
+     * @param templateId   the id at which to store the recovery code
      * @return the {@code AuthResult} of the action
      * @throws IOException when communication with the GateKeeper Card has been disrupted.
      * @since 0.10.0
@@ -422,10 +425,10 @@ public class GKAuthentication {
             if (mStatus == Status.UNAUTHORIZED) {
                 list.add(UNKNOWN_TEMPLATE);
             } else {
-                if (mResponse.getData() == null) {
+                if (mResponse.getDataFile() == null) {
                     return list;
                 }
-                List<String> templates = parseTemplateList(mResponse.getData());
+                List<String> templates = parseTemplateList(mResponse.getDataFile());
                 for (String template : templates) {
                     list.add(template);
                 }
@@ -433,11 +436,11 @@ public class GKAuthentication {
             return list;
         }
 
-        private List<String> parseTemplateList(byte[] response) {
-            String responseString = new String(response);
+        private List<String> parseTemplateList(File dataFile) {
+            String response = readDataFile(dataFile);
 
-            Pattern pattern = Pattern.compile(".*\r\n");
-            Matcher matcher = pattern.matcher(responseString);
+            Pattern pattern = Pattern.compile(GKFileUtils.DATA_LINE_PATTERN);
+            Matcher matcher = pattern.matcher(response);
 
             List<String> lineList = new ArrayList<>();
 
@@ -455,6 +458,15 @@ public class GKAuthentication {
             }
 
             return templateList;
+        }
+
+        private String readDataFile(File dataFile) {
+            try {
+                return GKFileUtils.readFile(dataFile);
+            } catch (IOException e) {
+                Log.e(TAG, "Error reading data file", e);
+                return "";
+            }
         }
     }
 }

--- a/app/src/main/java/co/blustor/gatekeepersdk/utils/GKFileUtils.java
+++ b/app/src/main/java/co/blustor/gatekeepersdk/utils/GKFileUtils.java
@@ -47,6 +47,11 @@ public class GKFileUtils {
                     YEAR_GROUP + NAME_GROUP + "$");
 
     /**
+     * Regex pattern for parsing data files by line
+     */
+    public static final String DATA_LINE_PATTERN = "(.*)(\r\n|\n)";
+
+    /**
      * @param fileData the data returned from a LIST command
      * @return a {@code GKFile} built from the fileData
      * @since 0.15.0

--- a/app/src/test/java/co/blustor/gatekeepersdk/biometrics/licensing/FetchExistingLicenseTest.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/biometrics/licensing/FetchExistingLicenseTest.java
@@ -1,6 +1,5 @@
 package co.blustor.gatekeepersdk.biometrics.licensing;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,6 +9,7 @@ import java.io.IOException;
 
 import co.blustor.gatekeepersdk.data.GKFile;
 import co.blustor.gatekeepersdk.services.GKFileActions;
+import co.blustor.gatekeepersdk.utils.TestFileUtil;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -31,17 +31,12 @@ public class FetchExistingLicenseTest {
         fileActions = mock(GKFileActions.class);
         subject = new FetchExistingLicense(fileActions);
 
-        tempLicenseFile = File.createTempFile("test-license", LicenseFileExtensions.LICENSE);
+        tempLicenseFile = TestFileUtil.buildTempFile();
         FileWriter licenseWriter = new FileWriter(tempLicenseFile);
         licenseWriter.write(licenseContents);
         licenseWriter.close();
 
         licenseFile = new GKFile("test.lic", GKFile.Type.FILE);
-    }
-
-    @After
-    public void tearDown() {
-        tempLicenseFile.delete();
     }
 
     @Test(expected = IOException.class)

--- a/app/src/test/java/co/blustor/gatekeepersdk/biometrics/licensing/GenerateActiveLicenseTest.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/biometrics/licensing/GenerateActiveLicenseTest.java
@@ -2,7 +2,6 @@ package co.blustor.gatekeepersdk.biometrics.licensing;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.internal.util.io.IOUtil;
@@ -21,6 +20,7 @@ import co.blustor.gatekeepersdk.data.GKFile;
 import co.blustor.gatekeepersdk.services.GKFileActions;
 import co.blustor.gatekeepersdk.utils.GKFileUtils;
 import co.blustor.gatekeepersdk.utils.GKStringUtils;
+import co.blustor.gatekeepersdk.utils.TestFileUtil;
 
 import static junit.framework.Assert.fail;
 import static org.hamcrest.Matchers.equalTo;
@@ -54,7 +54,7 @@ public class GenerateActiveLicenseTest {
         licenseManager = mock(BiometricLicenseManager.class);
         subject = new GenerateActiveLicense(licenseManager, fileActions, licenseSubdir);
 
-        tempSerialNumberFile = File.createTempFile("test-serial", LicenseFileExtensions.SERIAL_NUMBER);
+        tempSerialNumberFile = TestFileUtil.buildTempFile();
         FileWriter serialWriter = new FileWriter(tempSerialNumberFile);
         serialWriter.write(serialContents);
         serialWriter.close();
@@ -84,11 +84,6 @@ public class GenerateActiveLicenseTest {
 
         when(licenseManager.generateID(serialContents)).thenReturn(idContents);
         when(licenseManager.activateOnline(idContents)).thenReturn(licenseContents);
-    }
-
-    @After
-    public void tearDown() {
-        tempSerialNumberFile.delete();
     }
 
     @Test(expected = IOException.class)

--- a/app/src/test/java/co/blustor/gatekeepersdk/data/GKMultiplexerTest.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/data/GKMultiplexerTest.java
@@ -1,63 +1,157 @@
 package co.blustor.gatekeepersdk.data;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
+
+import co.blustor.gatekeepersdk.utils.GKFileUtils;
+import co.blustor.gatekeepersdk.utils.TestFileUtil;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 public class GKMultiplexerTest {
-
-    private GKMultiplexer multiplexer;
     private ByteArrayOutputStream outputStream;
 
     @Before
-    public void setUp() {
-        InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+    public void setUp() throws Exception {
         outputStream = new ByteArrayOutputStream();
-        multiplexer = new GKMultiplexer(inputStream, outputStream);
     }
 
     @Test
     public void writeToCommandChannelConstructsPacketAndWritesItToCommandChannel() throws IOException {
         byte[] input = {'x', 'y', 'z', 'j'};
+        GKMultiplexer multiplexer = buildMultiplexer(new byte[0]);
 
         multiplexer.writeToCommandChannel(input);
 
         byte[] expectedPacket = {GKMultiplexer.COMMAND_CHANNEL, 0, 9, 'x', 'y', 'z', 'j', 0, 0};
-        assertThat(outputStream.toByteArray(), is(Matchers.equalTo(expectedPacket)));
+        assertThat(outputStream.toByteArray(), is(equalTo(expectedPacket)));
     }
 
     @Test
     public void writeToDataChannelConstructsPacketAndWritesItToDataChannel() throws IOException {
         byte[] input = {'x', 'y', 'z', 'j'};
+        GKMultiplexer multiplexer = buildMultiplexer(new byte[0]);
 
         multiplexer.writeToDataChannel(input);
 
         byte[] expectedPacket = {GKMultiplexer.DATA_CHANNEL, 0, 9, 'x', 'y', 'z', 'j', 0, 0};
-        assertThat(outputStream.toByteArray(), is(Matchers.equalTo(expectedPacket)));
+        assertThat(outputStream.toByteArray(), is(equalTo(expectedPacket)));
     }
 
     @Test
     public void writeToDataChannelWithInputStreamBuffersPackets() throws Exception {
         byte[] input = new byte[GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 1];
         Arrays.fill(input, (byte) 'x');
+        GKMultiplexer multiplexer = buildMultiplexer(new byte[0]);
 
         multiplexer.writeToDataChannel(new ByteArrayInputStream(input));
 
         // should write in 2 packets of up to 256 bytes each, so 5 extra bytes per packet
         assertThat(outputStream.toByteArray().length, is(equalTo(GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 11)));
         byte[] firstPacketStart = {GKMultiplexer.DATA_CHANNEL, 1, 5, 'x'};
-        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), 0, 4), is(Matchers.equalTo(firstPacketStart)));
+        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), 0, 4), is(equalTo(firstPacketStart)));
         byte[] secondPacket = {GKMultiplexer.DATA_CHANNEL, 0, 6, 'x', 0, 0};
-        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 5, GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 11), is(Matchers.equalTo(secondPacket)));
+        assertThat(Arrays.copyOfRange(outputStream.toByteArray(), GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 5, GKMultiplexer.MAXIMUM_PAYLOAD_SIZE + 11), is(equalTo(secondPacket)));
+    }
+
+    @Test
+    public void readCommandChannelLineReadsUntilCRLF() throws IOException {
+        String commandLine1 = "reading this";
+        String commandLine2 = "this comes next";
+        byte[] commandResponse1 = DataPacket.Builder.toPacketBytes((commandLine1 + "\r\n    not read").getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+        byte[] commandResponse2 = DataPacket.Builder.toPacketBytes((commandLine2 + "\r\n").getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+        byte[] response = concat(commandResponse1, commandResponse2);
+        GKMultiplexer multiplexer = buildMultiplexer(response);
+
+        assertThat(multiplexer.readCommandChannelLine(), is(equalTo("reading this".getBytes())));
+        assertThat(multiplexer.readCommandChannelLine(), is(equalTo("this comes next".getBytes())));
+    }
+
+    @Test
+    public void readDataChannelToFileCopiesDataChannelDataToFile() throws IOException {
+        File dataFile = TestFileUtil.buildTempFile();
+        String dataLine = "this will be in a file";
+        String commandLine = "226 Transfer Complete.\r\n";
+        byte[] dataResponse = DataPacket.Builder.toPacketBytes(dataLine.getBytes(), GKMultiplexer.DATA_CHANNEL);
+        byte[] commandResponse = DataPacket.Builder.toPacketBytes(commandLine.getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+
+        GKMultiplexer multiplexer = buildMultiplexer(concat(dataResponse, commandResponse));
+        multiplexer.readDataChannelToFile(dataFile);
+
+        assertThat(readFile(dataFile), is(equalTo(dataLine)));
+    }
+
+    @Test
+    public void readDataChannelToFileCopiesMultipleDataChannelPacketsToFileUntilCommandChannelPacketComesUp() throws IOException {
+        File dataFile = TestFileUtil.buildTempFile();
+        String dataLine1 = "This will be in a file";
+        String dataLine2 = ". So will this.";
+        String commandLine = "226 Transfer Complete.\r\n";
+        byte[] dataResponse1 = DataPacket.Builder.toPacketBytes(dataLine1.getBytes(), GKMultiplexer.DATA_CHANNEL);
+        byte[] dataResponse2 = DataPacket.Builder.toPacketBytes(dataLine2.getBytes(), GKMultiplexer.DATA_CHANNEL);
+        byte[] commandResponse = DataPacket.Builder.toPacketBytes(commandLine.getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+        byte[] data = concat(dataResponse1, concat(dataResponse2, commandResponse));
+
+        GKMultiplexer multiplexer = buildMultiplexer(data);
+        multiplexer.readDataChannelToFile(dataFile);
+
+        assertThat(readFile(dataFile), is(equalTo(dataLine1 + dataLine2)));
+    }
+
+    @Test
+    public void readDataChannelReturnsTheResponseFromTheCommandChannel() throws IOException {
+        File dataFile = TestFileUtil.buildTempFile();
+        String dataLine = "x";
+        String commandLine = "226 Transfer Complete.";
+        byte[] dataResponse = DataPacket.Builder.toPacketBytes(dataLine.getBytes(), GKMultiplexer.DATA_CHANNEL);
+        byte[] commandResponse = DataPacket.Builder.toPacketBytes((commandLine + "\r\n").getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+
+        GKMultiplexer multiplexer = buildMultiplexer(concat(dataResponse, commandResponse));
+        byte[] commandData = multiplexer.readDataChannelToFile(dataFile);
+
+        assertThat(commandData, is(equalTo(commandLine.getBytes())));
+    }
+
+    @Test
+    public void readDataChannelReadsPacketsUntilACommandPacketHasCRLF() throws IOException {
+        File dataFile = TestFileUtil.buildTempFile();
+        String dataLine = "x";
+        String commandLine1 = "226 Transfer Complete.";
+        String commandLine2 = "for real. done.";
+        byte[] dataResponse = DataPacket.Builder.toPacketBytes(dataLine.getBytes(), GKMultiplexer.DATA_CHANNEL);
+        byte[] commandResponse1 = DataPacket.Builder.toPacketBytes(commandLine1.getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+        byte[] commandResponse2 = DataPacket.Builder.toPacketBytes((commandLine2 + "\r\n").getBytes(), GKMultiplexer.COMMAND_CHANNEL);
+        byte[] response = concat(dataResponse, concat(commandResponse1, commandResponse2));
+
+        GKMultiplexer multiplexer = buildMultiplexer(response);
+        byte[] commandData = multiplexer.readDataChannelToFile(dataFile);
+
+        assertThat(commandData, is(equalTo((commandLine1 + commandLine2).getBytes())));
+    }
+
+    private GKMultiplexer buildMultiplexer(byte[] responseData) {
+        return new GKMultiplexer(new ByteArrayInputStream(responseData), outputStream);
+    }
+
+    private byte[] concat(byte[] x, byte[] y) {
+        byte[] result = new byte[x.length + y.length];
+        System.arraycopy(x, 0, result, 0, x.length);
+        System.arraycopy(y, 0, result, x.length, y.length);
+
+        return result;
+    }
+
+    private String readFile(File file) throws IOException {
+        String contentsPlusNewline = GKFileUtils.readFile(file);
+        // -1 because GKFileUtils.readFile adds a newline at the end
+        return contentsPlusNewline.substring(0, contentsPlusNewline.length() - 1);
     }
 }

--- a/app/src/test/java/co/blustor/gatekeepersdk/services/GKCardSettingsTest.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/services/GKCardSettingsTest.java
@@ -2,10 +2,12 @@ package co.blustor.gatekeepersdk.services;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 import co.blustor.gatekeepersdk.devices.GKBluetoothCard;
 import co.blustor.gatekeepersdk.devices.GKCard;
+import co.blustor.gatekeepersdk.utils.TestFileUtil;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -18,8 +20,9 @@ public class GKCardSettingsTest {
     @Test
     public void getFirmwareInformationRetrievesTheVersion() throws IOException {
         GKCard card = mock(GKBluetoothCard.class);
-        GKCard.Response response = new GKCard.Response(226, "");
-        response.setData("BOOT:  2.0\r\nFIRM:    0.4.0\r\nTransfer complete.".getBytes());
+        File dataFile = TestFileUtil.buildTempFile();
+        TestFileUtil.writeToFile(dataFile, "BOOT:  2.0\r\nFIRM:    0.4.0\r\nTransfer complete.");
+        GKCard.Response response = new GKCard.Response(226, "", dataFile);
         when(card.get("/device/firmware")).thenReturn(response);
 
         GKCardSettings settings = new GKCardSettings(card);
@@ -28,6 +31,21 @@ public class GKCardSettingsTest {
         assertThat(result.getStatus(), equalTo(GKCardSettings.Status.SUCCESS));
         assertThat(result.getBootVersion(), equalTo("2.0"));
         assertThat(result.getFirmwareVersion(), equalTo("0.4.0"));
+    }
+
+    @Test
+    public void getFirmwareInformationReturnsErrorResultWhenVersionsCannotBeDetermined() throws IOException {
+        GKCard card = mock(GKBluetoothCard.class);
+        File dataFile = TestFileUtil.buildTempFile();
+        GKCard.Response response = new GKCard.Response(226, "", dataFile);
+        when(card.get("/device/firmware")).thenReturn(response);
+
+        GKCardSettings settings = new GKCardSettings(card);
+        GKCardSettings.FirmwareInformationResult result = settings.getFirmwareInformation();
+
+        assertThat(result.getStatus(), equalTo(GKCardSettings.Status.UNKNOWN_STATUS));
+        assertThat(result.getBootVersion(), is(nullValue()));
+        assertThat(result.getFirmwareVersion(), is(nullValue()));
     }
 
     @Test

--- a/app/src/test/java/co/blustor/gatekeepersdk/utils/TestFileUtil.java
+++ b/app/src/test/java/co/blustor/gatekeepersdk/utils/TestFileUtil.java
@@ -1,0 +1,20 @@
+package co.blustor.gatekeepersdk.utils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class TestFileUtil {
+    public static File buildTempFile() throws IOException {
+        File temp = File.createTempFile("test", "ing");
+        temp.deleteOnExit();
+        return temp;
+    }
+
+    public static void writeToFile(File file, String data) throws IOException {
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        fileOutputStream.write(data.getBytes(StandardCharsets.UTF_8));
+        fileOutputStream.close();
+    }
+}


### PR DESCRIPTION
This caused an issue where large enough files would blow up the heap,
which is limited on most android devices. This replaces all of the
threaded packet buffering with simply writing commands and reading
responses in a synchronous manner.

- `GKBluetoothCard` requires a dataCacheDir to store downloaded data to,
  which should normally be `context.getExternalCacheDir`