### PR TITLE
Release Version 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.16.3](https://github.com/BluStor/GateKeeperSDK/releases/tag/v0.16.3)
+* Write downloaded files to temp files, then copy to the final location
+    * This prevents partially downloaded files from appearing in the device Downloads directory
+
 ## [v0.16.2](https://github.com/BluStor/GateKeeperSDK/releases/tag/v0.16.2)
 * Fully disconnect on IOExceptions and verify connection before all card calls
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 19
-        versionCode 27
-        versionName "0.16.2"
+        versionCode 28
+        versionName "0.16.3"
     }
 
     buildTypes {


### PR DESCRIPTION
* Write downloaded files to temp files, then copy to the final location
    * This prevents partially downloaded files from appearing in the device Downloads directory